### PR TITLE
Collect all Composer-managed plugins together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Application
-web/app/plugins/*
+web/app/plugins/_*
 !web/app/plugins/.gitkeep
-web/app/mu-plugins/*/
+web/app/mu-plugins/_*/
 web/app/upgrade
 web/app/uploads/*
 !web/app/uploads/.gitkeep

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,8 @@
   "prefer-stable": true,
   "extra": {
     "installer-paths": {
-      "web/app/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
-      "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
+      "web/app/mu-plugins/_{$name}/": ["type:wordpress-muplugin"],
+      "web/app/plugins/_{$name}/": ["type:wordpress-plugin"],
       "web/app/themes/{$name}/": ["type:wordpress-theme"]
     },
     "wordpress-install-dir": "web/wp"


### PR DESCRIPTION
This is an idea that may need a little discussion. It shouldn't break anything (I have done a limited test) so it's a matter of whether or not we like the concept.

## What's Changed

The change groups all of the website's Composer based plugins together on the filesystem by prefixing each with an underscore as per the screenshot below.

![CleanShot 2023-04-15 at 17 14 24](https://user-images.githubusercontent.com/735284/232237336-bc467946-3571-42c7-bfbb-682485eae903.png)

## Reasoning

1. Our custom plugins (or third party ones what are not in Composer) are far easier to focus on when we are browsing the file system
2. When doing website updates it's clearer which plugins we are responsible for updating manually vs leaving up to Composer
3. All plugins beginning with `_` will be automatically ignored by Git, allowing all others to be version-controlled without having to manually whitelist them each time.

## Potential issues

Any plugin developer presuming to know their plugin's directory name and hardcoding it into their PHP will be caught out. To the best of my knowledge WP plugin directory names can be whatever a user wants though.